### PR TITLE
Fix link to Institute of Computer Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # 10915-01: Software Engineering
 
-Departement Mathematik und [Informatik](https://informatik.unibas.ch), Universit&auml;t Basel
+Departement Mathematik und [Informatik](http://informatik.unibas.ch/), Universit&auml;t Basel
 
 Dozent: Marcel L&uuml;thi (<marcel.luethi@unibas.ch>)
 


### PR DESCRIPTION
Sadly the institute website does not yet support HTTPS, so let's use http for now.