### PR TITLE
Corrected sentence with exam date

### DIFF
--- a/docs/slides/01-admin.html
+++ b/docs/slides/01-admin.html
@@ -418,7 +418,7 @@
 
 				<div style="border-width:2pt;border-style:solid">
 					<p>Schriftliche Pr&uuml;fung am
-						<mark class="highlight">17.1.2018</mark> Semesters.</p>
+						<mark class="highlight">17.1.2018</mark>.</p>
 				</div>
 				<br/>
 				<ul>


### PR DESCRIPTION
Removed `Semesters` from the end of the sentence which appears to be a leftover from an edit.