### PR TITLE
Add teaching assistant information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Departement Mathematik und [Informatik](http://informatik.unibas.ch/), Universit
 
 Dozent: Marcel Lüthi (<marcel.luethi@unibas.ch>)
 
-Tutor: Michael Plüss (<m.pluess@unibas.ch>, Github: <https://github.com/>)
+Tutor: Michael Plüss (<m.pluess@unibas.ch>, Github: <https://github.com/MrStranded>)
 
 Tutor: Jan Schönholz (<jan.schoenholz@unibas.ch>, Github: <https://github.com/schoenja>)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Departement Mathematik und [Informatik](http://informatik.unibas.ch/), Universit
 
 Dozent: Marcel Lüthi (<marcel.luethi@unibas.ch>)
 
+Tutor: Michael Plüss (<m.pluess@unibas.ch>)
+
+Tutor: Jan Schönholz (<jan.schoenholz@unibas.ch>)
+
 ## Kursbeschreibung
 
 Die Vorlesung gibt eine erste Einführung in das Software Engineering. 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Departement Mathematik und [Informatik](http://informatik.unibas.ch/), Universit
 
 Dozent: Marcel Lüthi (<marcel.luethi@unibas.ch>)
 
-Tutor: Michael Plüss (<m.pluess@unibas.ch>)
+Tutor: Michael Plüss (<m.pluess@unibas.ch>, Github: <https://github.com/>)
 
-Tutor: Jan Schönholz (<jan.schoenholz@unibas.ch>)
+Tutor: Jan Schönholz (<jan.schoenholz@unibas.ch>, Github: <https://github.com/schoenja>)
 
 ## Kursbeschreibung
 


### PR DESCRIPTION
Add the names and email addresses of the teaching assistants to the README.

This will allow students to easily find the information to contact them.

